### PR TITLE
Add test for deleting shelter only if pets are rejected

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -39,6 +39,7 @@ class SheltersController < ApplicationController
   end
 
   def destroy
+    
     Shelter.destroy(params[:id])
     redirect_to '/shelters'
   end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -1,6 +1,7 @@
 class Pet <ApplicationRecord
   belongs_to :shelter
 
+  has_many :pet_applications, dependent: :destroy
   has_many :user_applications, through: :pet_applications
 
   def self.count_pets(shelter_id)

--- a/spec/features/shelters/show_spec.rb
+++ b/spec/features/shelters/show_spec.rb
@@ -75,5 +75,37 @@ describe 'As a visitor' do
       expect(page).to have_content("Average Rating: 5")
       expect(page).to have_content("Number of Applications: 1")
     end
+    it "If a shelter doesn't have any pets with an approved application I can delete that shelter" do
+        shelter_1 = Shelter.create(name: 'Dumb Friends League',
+        address: '123 ABC Street',
+        city: 'Denver',
+        state: 'Colorado',
+        zip: '12345')
+        user_1 = User.create(name: 'Jose',
+          address: '123 ABC Street',
+          city: 'Denver',
+          state: 'Colorado',
+          zip: '12345')
+         
+          pet_1 = Pet.create(image: 'lib/assets/test_image',
+              name: 'Test_dog',
+              age: 5,
+              sex: 'male',
+              shelter_id: shelter_1.id)
+
+
+        application = UserApplication.create!(name: "Jose", address: "", city: "", state: "", zip:"",
+              description: "", status: "", user_id: user_1.id)
+
+              PetApplication.create(pet_id: pet_1.id, user_application_id: application.id, status: "rejected")
+
+        visit "/shelters/#{shelter_1.id}"
+
+        expect(shelter_1.pets[0]).to eq(pet_1)
+
+        click_button "Delete Shelter"
+        
+        expect(current_path).to eq("/shelters")
+    end
   end
 end


### PR DESCRIPTION
This Branch Does:
- Add feature to not allow shelters to be deleted if pets are pending or approved
- Fixes many to many of pets and pet_applications
All tests passing